### PR TITLE
fix: filters out children with empty ("") data node

### DIFF
--- a/examples/pages/plain-html.html
+++ b/examples/pages/plain-html.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Plain HTML page</title>
+  </head>
+  <body>
+    <div>
+      hello world
+    </div>
+  </body>
+</html>

--- a/pkg/parser/html/debug.go
+++ b/pkg/parser/html/debug.go
@@ -7,7 +7,6 @@ import (
 	"golang.org/x/net/html"
 )
 
-
 func nodePrinter(n *html.Node, withChildren bool) (string, []string) {
 	if n == nil {
 		panic("called with nil node")
@@ -18,7 +17,7 @@ func nodePrinter(n *html.Node, withChildren bool) (string, []string) {
 		attrs = append(attrs, fmt.Sprintf("%s=%s", attr.Key, attr.Val))
 	}
 
-	children := getChildren(n)
+	children := getFilteredChildren(n)
 	childrenMsg := make([]string, 0, len(children))
 	if withChildren {
 		for _, child := range children {

--- a/pkg/parser/html/printer.go
+++ b/pkg/parser/html/printer.go
@@ -7,6 +7,9 @@ import (
 )
 
 func renderHTML(w io.Writer, n *html.Node) error {
+	if n == nil {
+		return nil
+	}
 	logger.Debug("RENDERING html")
 	return html.Render(w, n)
 }

--- a/pkg/parser/html/traversal.go
+++ b/pkg/parser/html/traversal.go
@@ -21,7 +21,7 @@ func getFilteredChildren(n *html.Node) []*html.Node {
 	var result []*html.Node
 	for c := n.FirstChild; c != nil; c = c.NextSibling {
 		if strings.TrimSpace(c.Data) == "" {
-			// INFO: omiting empty node
+			// INFO: omitting empty node
 			continue
 		}
 		result = append(result, c)
@@ -34,7 +34,7 @@ func filterChildren(nodes []*html.Node) []*html.Node {
 	var result []*html.Node
 	for _, c := range nodes {
 		if strings.TrimSpace(c.Data) == "" {
-			// INFO: omiting empty node
+			// INFO: omitting empty node
 			continue
 		}
 		result = append(result, c)

--- a/pkg/parser/html/traversal.go
+++ b/pkg/parser/html/traversal.go
@@ -16,9 +16,23 @@ func parseReader(r io.Reader, traverse func(*html.Node) error) error {
 	return traverse(n)
 }
 
-func getChildren(n *html.Node) []*html.Node {
+// getFilteredChildren filters out children that are not ""
+func getFilteredChildren(n *html.Node) []*html.Node {
 	var result []*html.Node
 	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		if strings.TrimSpace(c.Data) == "" {
+			// INFO: omiting empty node
+			continue
+		}
+		result = append(result, c)
+	}
+
+	return result
+}
+
+func filterChildren(nodes []*html.Node) []*html.Node {
+	var result []*html.Node
+	for _, c := range nodes {
 		if strings.TrimSpace(c.Data) == "" {
 			// INFO: omiting empty node
 			continue

--- a/pkg/parser/template/parser.go
+++ b/pkg/parser/template/parser.go
@@ -184,9 +184,6 @@ type Parser struct {
 
 	parsedStructFileTemplate  *template.Template
 	parsedPkgInitFileTemplate *template.Template
-
-	// allTemplates *template.Template
-	// postProcess  func(t *template.Template) (string, error)
 }
 
 type ParseOptions struct {


### PR DESCRIPTION
Resolves #2

which caused generate failing on plain html files

## Summary by Sourcery

Bug Fixes:
- Fixes a bug where the parser would fail on plain HTML files due to empty data nodes.

## Summary by Sourcery

Bug Fixes:
- Fixes a bug where the parser would fail on plain HTML files due to empty data nodes.